### PR TITLE
Making plugin follow Apple guidelines for UIWebView

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-appversion",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Access the native app version & build number in JavaScript",
   "cordova": {
     "id": "cordova-plugin-appversion",
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Rareloop/cordova-plugin-app-version.git"
+    "url": "https://github.com/davipcruz/cordova-plugin-app-version.git"
   },
   "keywords": [
     "cordova",
@@ -23,7 +23,7 @@
   "author": "Rareloop (http://rareloop.com)",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/Rareloop/cordova-plugin-app-version/issues"
+    "url": "https://github.com/davidpcruz/cordova-plugin-app-version/issues"
   },
-  "homepage": "https://github.com/Rareloop/cordova-plugin-app-version"
+  "homepage": "https://github.com/davidpcruz/cordova-plugin-app-version"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-appversion",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Access the native app version & build number in JavaScript",
   "cordova": {
     "id": "cordova-plugin-appversion",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-        id="cordova-plugin-appversion" version="1.0.0">
+        id="cordova-plugin-appversion" version="1.1">
     <name>App Version</name>
     <description>Expose the native app version to JavaScript</description>
     <license>MIT</license>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-        id="cordova-plugin-appversion" version="1.1">
+        id="cordova-plugin-appversion" version="1.1.1">
     <name>App Version</name>
     <description>Expose the native app version to JavaScript</description>
     <license>MIT</license>

--- a/src/ios/RareloopAppVersion.h
+++ b/src/ios/RareloopAppVersion.h
@@ -22,7 +22,7 @@
 
 #import <Cordova/CDV.h>
 
-@interface RareloopAppVersion : CDVPlugin <UIWebViewDelegate>
+@interface RareloopAppVersion : CDVPlugin 
 {
 }
 


### PR DESCRIPTION
Hello,

Took the liberty of forking the plugin and modifying the single line you see below to now use UIWebViewDelegate generic. This will remove any reference to UIWebView from Cordova apps and avoid any "ITMS-90809 Deprecated API" warnings.

Could you merge so anyone using the original repository benefit from these changes?

Thanks in advance,
Carlos